### PR TITLE
Friend Map Presentation: Added FriendMap screen and AppFlowFactory

### DIFF
--- a/FriendFinder.xcodeproj/project.pbxproj
+++ b/FriendFinder.xcodeproj/project.pbxproj
@@ -17,6 +17,13 @@
 		E53BE19925516F46008D48DB /* FriendTrackerRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53BE19825516F46008D48DB /* FriendTrackerRepository.swift */; };
 		E53BE1A025517972008D48DB /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53BE19F25517972008D48DB /* User.swift */; };
 		E55106E125517C8700E3F0A3 /* LocationUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55106E025517C8700E3F0A3 /* LocationUpdate.swift */; };
+		E564875D25518A990028C18D /* FriendMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E564875C25518A990028C18D /* FriendMapViewController.swift */; };
+		E564876325518AE20028C18D /* FriendMapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E564876225518AE20028C18D /* FriendMapViewModel.swift */; };
+		E564876A25518BA80028C18D /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E564876925518BA80028C18D /* BaseViewController.swift */; };
+		E564877D25519CB20028C18D /* MKMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E564877C25519CB20028C18D /* MKMapView.swift */; };
+		E56487852551E0EB0028C18D /* UserAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56487842551E0EB0028C18D /* UserAnnotationView.swift */; };
+		E56487892551E1040028C18D /* UserAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E56487882551E1040028C18D /* UserAnnotation.swift */; };
+		E564878D2551E50E0028C18D /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E564878C2551E50E0028C18D /* UIImage.swift */; };
 		E5A77C80254DAB0F00B6B25D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A77C7F254DAB0F00B6B25D /* AppDelegate.swift */; };
 		E5A77C82254DAB0F00B6B25D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A77C81254DAB0F00B6B25D /* SceneDelegate.swift */; };
 		E5A77C89254DAB1000B6B25D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E5A77C88254DAB1000B6B25D /* Assets.xcassets */; };
@@ -24,6 +31,7 @@
 		E5A77CF3254DAFC800B6B25D /* AppFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A77CF2254DAFC800B6B25D /* AppFlowCoordinator.swift */; };
 		E5A77D01254DB1AF00B6B25D /* AppFlowFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A77D00254DB1AF00B6B25D /* AppFlowFactory.swift */; };
 		E5A77D0B254DB8E100B6B25D /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A77D0A254DB8E100B6B25D /* AppAppearance.swift */; };
+		E5FE429725520AA400DD6B34 /* CLLocationCoordinate2D.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5FE429625520AA400DD6B34 /* CLLocationCoordinate2D.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +55,13 @@
 		E53BE19825516F46008D48DB /* FriendTrackerRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FriendTrackerRepository.swift; sourceTree = "<group>"; };
 		E53BE19F25517972008D48DB /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		E55106E025517C8700E3F0A3 /* LocationUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationUpdate.swift; sourceTree = "<group>"; };
+		E564875C25518A990028C18D /* FriendMapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendMapViewController.swift; sourceTree = "<group>"; };
+		E564876225518AE20028C18D /* FriendMapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendMapViewModel.swift; sourceTree = "<group>"; };
+		E564876925518BA80028C18D /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		E564877C25519CB20028C18D /* MKMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MKMapView.swift; sourceTree = "<group>"; };
+		E56487842551E0EB0028C18D /* UserAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAnnotationView.swift; sourceTree = "<group>"; };
+		E56487882551E1040028C18D /* UserAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAnnotation.swift; sourceTree = "<group>"; };
+		E564878C2551E50E0028C18D /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		E5A77C7C254DAB0F00B6B25D /* FriendFinder.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FriendFinder.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5A77C7F254DAB0F00B6B25D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E5A77C81254DAB0F00B6B25D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -62,6 +77,7 @@
 		E5A77D00254DB1AF00B6B25D /* AppFlowFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFlowFactory.swift; sourceTree = "<group>"; };
 		E5A77D0A254DB8E100B6B25D /* AppAppearance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppAppearance.swift; sourceTree = "<group>"; };
 		E5A77D0E254DB92C00B6B25D /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = SOURCE_ROOT; };
+		E5FE429625520AA400DD6B34 /* CLLocationCoordinate2D.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLLocationCoordinate2D.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -146,6 +162,67 @@
 			path = Entities;
 			sourceTree = "<group>";
 		};
+		E5648758255189560028C18D /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				E564875B2551896F0028C18D /* ViewControllers */,
+				E56487592551895E0028C18D /* ViewModels */,
+				E564875A255189670028C18D /* Views */,
+				E564876625518B8A0028C18D /* Common */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		E56487592551895E0028C18D /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				E564876225518AE20028C18D /* FriendMapViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		E564875A255189670028C18D /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				E56487842551E0EB0028C18D /* UserAnnotationView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		E564875B2551896F0028C18D /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				E564875C25518A990028C18D /* FriendMapViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		E564876625518B8A0028C18D /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				E564876725518B900028C18D /* ViewControllers */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		E564876725518B900028C18D /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				E564876925518BA80028C18D /* BaseViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		E564877B25519CA30028C18D /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E564878C2551E50E0028C18D /* UIImage.swift */,
+				E564877C25519CB20028C18D /* MKMapView.swift */,
+				E5FE429625520AA400DD6B34 /* CLLocationCoordinate2D.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		E5A77C73254DAB0F00B6B25D = {
 			isa = PBXGroup;
 			children = (
@@ -172,7 +249,9 @@
 				E5A77D0A254DB8E100B6B25D /* AppAppearance.swift */,
 				E5A77CF2254DAFC800B6B25D /* AppFlowCoordinator.swift */,
 				E5A77D00254DB1AF00B6B25D /* AppFlowFactory.swift */,
+				E5648758255189560028C18D /* Presentation */,
 				E51E870C2551584D00032B96 /* Data */,
+				E5FE429F2552165A00DD6B34 /* Utilities */,
 				E5A77CD2254DAD9400B6B25D /* Resources */,
 			);
 			path = FriendFinder;
@@ -199,6 +278,15 @@
 				E5A77C88254DAB1000B6B25D /* Assets.xcassets */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		E5FE429F2552165A00DD6B34 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				E56487882551E1040028C18D /* UserAnnotation.swift */,
+				E564877B25519CA30028C18D /* Extensions */,
+			);
+			path = Utilities;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -300,19 +388,27 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E564876325518AE20028C18D /* FriendMapViewModel.swift in Sources */,
 				E51E86FD2551518200032B96 /* DataTransferService.swift in Sources */,
 				E53BE1A025517972008D48DB /* User.swift in Sources */,
 				E55106E125517C8700E3F0A3 /* LocationUpdate.swift in Sources */,
+				E564875D25518A990028C18D /* FriendMapViewController.swift in Sources */,
 				E5A77CF3254DAFC800B6B25D /* AppFlowCoordinator.swift in Sources */,
 				E51E87172551597700032B96 /* Credentials.swift in Sources */,
 				E51E86F12551515600032B96 /* TCPConnectionService.swift in Sources */,
 				E53BE19925516F46008D48DB /* FriendTrackerRepository.swift in Sources */,
 				E5A77C80254DAB0F00B6B25D /* AppDelegate.swift in Sources */,
 				E5A77D01254DB1AF00B6B25D /* AppFlowFactory.swift in Sources */,
+				E564877D25519CB20028C18D /* MKMapView.swift in Sources */,
+				E56487852551E0EB0028C18D /* UserAnnotationView.swift in Sources */,
 				E5A77C82254DAB0F00B6B25D /* SceneDelegate.swift in Sources */,
 				E51E86F52551516500032B96 /* UserMessage.swift in Sources */,
+				E564876A25518BA80028C18D /* BaseViewController.swift in Sources */,
+				E564878D2551E50E0028C18D /* UIImage.swift in Sources */,
+				E56487892551E1040028C18D /* UserAnnotation.swift in Sources */,
 				E51E86F92551516A00032B96 /* UpdateMessage.swift in Sources */,
 				E5A77D0B254DB8E100B6B25D /* AppAppearance.swift in Sources */,
+				E5FE429725520AA400DD6B34 /* CLLocationCoordinate2D.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FriendFinder.xcodeproj/xcshareddata/xcschemes/FriendFinder.xcscheme
+++ b/FriendFinder.xcodeproj/xcshareddata/xcschemes/FriendFinder.xcscheme
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1210"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E5A77C7B254DAB0F00B6B25D"
+               BuildableName = "FriendFinder.app"
+               BlueprintName = "FriendFinder"
+               ReferencedContainer = "container:FriendFinder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E5A77C91254DAB1000B6B25D"
+               BuildableName = "FriendFinderTests.xctest"
+               BlueprintName = "FriendFinderTests"
+               ReferencedContainer = "container:FriendFinder.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E5A77C7B254DAB0F00B6B25D"
+            BuildableName = "FriendFinder.app"
+            BlueprintName = "FriendFinder"
+            ReferencedContainer = "container:FriendFinder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disabled"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E5A77C7B254DAB0F00B6B25D"
+            BuildableName = "FriendFinder.app"
+            BlueprintName = "FriendFinder"
+            ReferencedContainer = "container:FriendFinder.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FriendFinder/AppFlowCoordinator.swift
+++ b/FriendFinder/AppFlowCoordinator.swift
@@ -7,9 +7,13 @@
 
 import UIKit
 
+// MARK: Coordinator
+
 protocol Coordinator: AnyObject {
     func start()
 }
+
+// MARK: AppFlowCoordinator
 
 final class AppFlowCoordinator: Coordinator {
 
@@ -25,9 +29,7 @@ final class AppFlowCoordinator: Coordinator {
     }
 
     func start() {
-        // FIXME: Replace with `factory` initialization call
-        let viewController = UIViewController()
-        viewController.view.backgroundColor = .systemBlue
+        let viewController = factory.makeFriendMapViewController()
 
         presenter.setViewControllers(
             [viewController],

--- a/FriendFinder/AppFlowFactory.swift
+++ b/FriendFinder/AppFlowFactory.swift
@@ -7,6 +7,52 @@
 
 import Foundation
 
-protocol AppFlowFactory: AnyObject { }
+// MARK: AppFlowFactory
 
-final class AppFlowFactoryImpl: AppFlowFactory { }
+protocol AppFlowFactory: AnyObject {
+    func makeFriendMapViewController() -> FriendMapViewController
+}
+
+// MARK: AppFlowFactoryImpl
+
+final class AppFlowFactoryImpl: AppFlowFactory {
+
+    // MARK: DataTransfer
+
+    private lazy var dataTransferService: DataTransferService = {
+        let tcpConnectionService = TCPConnectionServiceImpl(
+            credentials: Credentials(
+                email: "edgars.vanags1@gmail.com"
+            ),
+            host: "ios-test.printful.lv",
+            port: 6111
+        )
+        let dataTransferService = DataTransferServiceImpl(
+            tcpConnectionService: tcpConnectionService
+        )
+
+        return dataTransferService
+    }()
+
+    // MARK: FriendMap
+
+    func makeFriendMapViewController() -> FriendMapViewController {
+        FriendMapViewController(
+            viewModel: makeFriendMapViewModel()
+        )
+    }
+
+    private func makeFriendMapViewModel() -> FriendMapViewModel {
+        FriendMapViewModelImpl(
+            repository: makeFriendTrackerRepository()
+        )
+    }
+
+    // MARK: Repositories
+
+    private func makeFriendTrackerRepository() -> FriendTrackerRepository {
+        FriendTrackerRepositoryImpl(
+            dataTransferService: dataTransferService
+        )
+    }
+}

--- a/FriendFinder/Data/Repositories/Entities/LocationUpdate.swift
+++ b/FriendFinder/Data/Repositories/Entities/LocationUpdate.swift
@@ -10,5 +10,5 @@ import CoreLocation
 
 struct LocationUpdate: Identifiable {
     let id: Int
-    let location: CLLocation
+    let coordinate: CLLocationCoordinate2D
 }

--- a/FriendFinder/Data/Repositories/Entities/User.swift
+++ b/FriendFinder/Data/Repositories/Entities/User.swift
@@ -12,5 +12,5 @@ struct User: Identifiable {
     let id: Int
     let fullName: String
     let imageURL: URL
-    let location: CLLocation
+    let coordinate: CLLocationCoordinate2D
 }

--- a/FriendFinder/Data/Repositories/FriendTrackerRepository.swift
+++ b/FriendFinder/Data/Repositories/FriendTrackerRepository.swift
@@ -42,7 +42,7 @@ extension FriendTrackerRepositoryImpl: FriendTrackerRepository {
                         id: message.id,
                         fullName: message.fullName,
                         imageURL: message.imageURL,
-                        location: CLLocation(
+                        coordinate: CLLocationCoordinate2D(
                             latitude: message.latitude,
                             longitude: message.longitude
                         )
@@ -53,7 +53,7 @@ extension FriendTrackerRepositoryImpl: FriendTrackerRepository {
                 onLocationUpdate(
                     LocationUpdate(
                         id: message.id,
-                        location: CLLocation(
+                        coordinate: CLLocationCoordinate2D(
                             latitude: message.latitude,
                             longitude: message.longitude
                         )

--- a/FriendFinder/Presentation/Common/ViewControllers/BaseViewController.swift
+++ b/FriendFinder/Presentation/Common/ViewControllers/BaseViewController.swift
@@ -1,0 +1,62 @@
+//
+//  MacOS 10.15
+//  Swift 5.0
+//  FriendFinder
+//  @esesmuedgars
+//
+
+import UIKit
+
+// MARK: ViewController
+
+public protocol ViewController: NSObjectProtocol {
+    associatedtype ViewModel
+
+    var viewModel: ViewModel! { get set }
+
+    func setup()
+    func bind(to viewModel: ViewModel)
+}
+
+// MARK: BaseViewController
+
+open class BaseViewController<ViewModel>: UIViewController, ViewController {
+
+    public var viewModel: ViewModel!
+
+    public init(viewModel: ViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+
+        setup()
+    }
+
+    @available(*, unavailable)
+    public override init(
+        nibName nibNameOrNil: String?,
+        bundle nibBundleOrNil: Bundle?
+    ) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+
+    @available(*, unavailable)
+    required public init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+
+        bind(to: viewModel)
+    }
+
+    /// Method for `ViewController` subclass setup.
+    /// Called by `init(viewModel:)`.
+    open func setup() { }
+
+    /// Method to bind `ViewController` properties with `ViewModel` datasource.
+    /// Called by `viewDidLoad()`.
+    /// - Parameter viewModel: datasource of `ViewController` properties.
+    open func bind(to viewModel: ViewModel) { }
+}
+

--- a/FriendFinder/Presentation/ViewControllers/FriendMapViewController.swift
+++ b/FriendFinder/Presentation/ViewControllers/FriendMapViewController.swift
@@ -1,0 +1,123 @@
+//
+//  MacOS 10.15
+//  Swift 5.0
+//  FriendFinder
+//  @esesmuedgars
+//
+
+import UIKit
+import MapKit
+
+final class FriendMapViewController: BaseViewController<FriendMapViewModel> {
+
+    private lazy var mapView: MKMapView = {
+        let mapView = MKMapView()
+        mapView.delegate = self
+
+        return mapView
+    }()
+
+    override func loadView() {
+        view = mapView
+    }
+
+    override func bind(to viewModel: FriendMapViewModel) {
+        setRigaRegion()
+
+        viewModel.beginTrackingFriends(
+            onNextUser: handleNextUser,
+            onLocationUpdate: handleLocationUpdate
+        )
+    }
+
+    private func setRigaRegion() {
+        mapView.setRegion(
+            MKCoordinateRegion(
+                center: .rigaCoordinate,
+                span: MKCoordinateSpan(
+                    latitudeDelta: 0.02,
+                    longitudeDelta: 0.02
+                )
+            ),
+            animated: false
+        )
+    }
+
+    private func handleNextUser(_ user: User) {
+        let annotation = UserAnnotation(
+            id: user.id,
+            image: UIImage(url: user.imageURL),
+            title: user.fullName,
+            coordinate: user.coordinate
+        )
+
+        DispatchQueue.main.async {
+            self.mapView.addAnnotation(annotation)
+        }
+    }
+
+    private func handleLocationUpdate(_ locationUpdate: LocationUpdate) {
+        guard let annotation = self.mapView.annotations
+                .firstWithId(locationUpdate.id),
+              !annotation.coordinate.isEqual(locationUpdate.coordinate) else {
+            return
+        }
+
+        viewModel.reverseGeocodeLocation(annotation)
+
+        DispatchQueue.main.async {
+            UIView.animate(
+                withDuration: 0.3,
+                delay: .zero,
+                options: [.curveLinear, .preferredFramesPerSecond60]
+            ) {
+                annotation.coordinate = locationUpdate.coordinate
+            }
+        }
+    }
+}
+
+// MARK: MKMapViewDelegate
+
+extension FriendMapViewController: MKMapViewDelegate {
+    func mapView(
+        _ mapView: MKMapView,
+        viewFor annotation: MKAnnotation
+    ) -> MKAnnotationView? {
+        guard let annotation = annotation as? UserAnnotation else {
+            return nil
+        }
+
+        viewModel.reverseGeocodeLocation(annotation)
+
+        guard let annotationView = mapView.dequeueReusableAnnotationView(
+            ofType: UserAnnotationView.self
+        ) else {
+            return UserAnnotationView(annotation: annotation)
+        }
+
+        annotationView.annotation = annotation
+
+        return annotationView
+    }
+}
+
+// MARK: CLLocationCoordinate2D
+
+fileprivate extension CLLocationCoordinate2D {
+    static var rigaCoordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(
+            latitude: 56.9496,
+            longitude: 24.1052
+        )
+    }
+}
+
+// MARK: Sequence
+
+fileprivate extension Sequence where Element: MKAnnotation {
+    func firstWithId(_ id: Int) -> UserAnnotation? {
+        compactMap { $0 as? UserAnnotation }
+            .first { $0.id == id }
+    }
+}

--- a/FriendFinder/Presentation/ViewModels/FriendMapViewModel.swift
+++ b/FriendFinder/Presentation/ViewModels/FriendMapViewModel.swift
@@ -1,0 +1,79 @@
+//
+//  MacOS 10.15
+//  Swift 5.0
+//  FriendFinder
+//  @esesmuedgars
+//
+
+import Foundation
+import CoreLocation
+
+// MARK: FriendMapViewModelInput
+
+protocol FriendMapViewModelInput: AnyObject {
+    func beginTrackingFriends(
+        onNextUser: @escaping (User) -> Void,
+        onLocationUpdate: @escaping (LocationUpdate) -> Void
+    )
+    func reverseGeocodeLocation(_ annotation: UserAnnotation)
+}
+
+// MARK: FriendMapViewModelOutput
+
+protocol FriendMapViewModelOutput: AnyObject { }
+
+// MARK: HomeTabViewModel
+
+protocol FriendMapViewModel: FriendMapViewModelInput, FriendMapViewModelOutput { }
+
+// MARK: FriendMapViewModelImpl
+
+final class FriendMapViewModelImpl: FriendMapViewModel {
+
+    private let geocoderQueue = DispatchQueue(
+        label: "CLGeocoderSerialQueue",
+        qos: .userInteractive
+    )
+    private let condition = NSCondition()
+    private lazy var geocoder =  CLGeocoder()
+
+    private let repository: FriendTrackerRepository
+
+    init(repository: FriendTrackerRepository) {
+        self.repository = repository
+    }
+
+    func beginTrackingFriends(
+        onNextUser: @escaping (User) -> Void,
+        onLocationUpdate: @escaping (LocationUpdate) -> Void
+    ) {
+        repository.beginTrackingFriends(
+            onNextUser: onNextUser,
+            onLocationUpdate: onLocationUpdate,
+            onError: { error in
+                #if DEBUG
+                print("⚠️", error)
+                #endif
+            }
+        )
+    }
+
+    func reverseGeocodeLocation(_ annotation: UserAnnotation) {
+        geocoderQueue.async {
+            self.condition.lock()
+
+            while self.geocoder.isGeocoding {
+                self.condition.wait()
+            }
+
+            self.geocoder.reverseGeocodeLocation(annotation.location) { placemarks, _ in
+                if let placemark = placemarks?.first {
+                    annotation.subtitle = placemark.name
+                }
+
+                self.condition.signal()
+                self.condition.unlock()
+            }
+        }
+    }
+}

--- a/FriendFinder/Presentation/Views/UserAnnotationView.swift
+++ b/FriendFinder/Presentation/Views/UserAnnotationView.swift
@@ -1,0 +1,64 @@
+//
+//  MacOS 10.15
+//  Swift 5.0
+//  FriendFinder
+//  @esesmuedgars
+//
+
+import MapKit
+
+final class UserAnnotationView: MKAnnotationView {
+
+    init(annotation: UserAnnotation) {
+        super.init(
+            annotation: annotation,
+            reuseIdentifier: String(describing: type(of: self))
+        )
+
+        setup()
+    }
+
+    @available(*, unavailable)
+    init() {
+        super.init(annotation: nil, reuseIdentifier: nil)
+    }
+
+    @available(*, unavailable)
+    override init(
+        annotation: MKAnnotation?,
+        reuseIdentifier: String?
+    ) {
+        super.init(
+            annotation: annotation,
+            reuseIdentifier: reuseIdentifier
+        )
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    private func setup() {
+        canShowCallout = true
+
+        let configuration = UIImage.SymbolConfiguration(scale: .large)
+        image = UIImage(systemName: "figure.walk")?
+            .applyingSymbolConfiguration(configuration)
+
+        setLeftCalloutImageView()
+    }
+
+    private func setLeftCalloutImageView() {
+        guard let annotation = annotation as? UserAnnotation else {
+            return
+        }
+
+        let imageView = UIImageView(
+            image: annotation.image?.withSize(
+                CGSize(width: 40, height: 40)
+            )
+        )
+        leftCalloutAccessoryView = imageView
+    }
+}

--- a/FriendFinder/Utilities/Extensions/CLLocationCoordinate2D.swift
+++ b/FriendFinder/Utilities/Extensions/CLLocationCoordinate2D.swift
@@ -1,0 +1,15 @@
+//
+//  MacOS 10.15
+//  Swift 5.0
+//  FriendFinder
+//  @esesmuedgars
+//
+
+import CoreLocation
+
+public extension CLLocationCoordinate2D {
+    func isEqual(_ coordinate: CLLocationCoordinate2D) -> Bool {
+        latitude == coordinate.latitude &&
+            longitude == coordinate.longitude
+    }
+}

--- a/FriendFinder/Utilities/Extensions/MKMapView.swift
+++ b/FriendFinder/Utilities/Extensions/MKMapView.swift
@@ -1,0 +1,20 @@
+//
+//  MacOS 10.15
+//  Swift 5.0
+//  FriendFinder
+//  @esesmuedgars
+//
+
+import MapKit
+
+public extension MKMapView {
+    func dequeueReusableAnnotationView<AnnotationView: MKAnnotationView>(
+        ofType type: AnnotationView.Type
+    ) -> MKAnnotationView? {
+        dequeueReusableAnnotationView(
+            withIdentifier: String(
+                describing: type
+            )
+        ) as? AnnotationView
+    }
+}

--- a/FriendFinder/Utilities/Extensions/UIImage.swift
+++ b/FriendFinder/Utilities/Extensions/UIImage.swift
@@ -1,0 +1,24 @@
+//
+//  MacOS 10.15
+//  Swift 5.0
+//  FriendFinder
+//  @esesmuedgars
+//
+
+import UIKit
+
+public extension UIImage {
+    convenience init?(url: URL) {
+        guard let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+
+        self.init(data: data)
+    }
+
+    func withSize(_ size: CGSize) -> UIImage? {
+        UIGraphicsImageRenderer(size: size).image { [weak self] _ in
+            self?.draw(in: CGRect(origin: .zero, size: size))
+        }
+    }
+}

--- a/FriendFinder/Utilities/UserAnnotation.swift
+++ b/FriendFinder/Utilities/UserAnnotation.swift
@@ -1,0 +1,36 @@
+//
+//  MacOS 10.15
+//  Swift 5.0
+//  FriendFinder
+//  @esesmuedgars
+//
+
+import MapKit
+
+final class UserAnnotation: NSObject, MKAnnotation, Identifiable {
+
+    let id: Int
+    let image: UIImage?
+    let title: String?
+    @objc dynamic var subtitle: String?
+    @objc dynamic var coordinate: CLLocationCoordinate2D
+
+    var location: CLLocation {
+        CLLocation(
+            latitude: coordinate.latitude,
+            longitude: coordinate.longitude
+        )
+    }
+
+    init(
+        id: Int,
+        image: UIImage?,
+        title: String?,
+        coordinate: CLLocationCoordinate2D
+    ) {
+        self.id = id
+        self.image = image
+        self.title = title
+        self.coordinate = coordinate
+    }
+}


### PR DESCRIPTION
# Friend Map Presentation

- Implemented `AppFlowFactory` to initialize all dependencies;
- Added `AppFlowCoordinator` call to initialize `FriendMapViewController`;
- Implemented `FriendMapViewController`;
- Added `UserAnnotationView` subclass of `MKAnnotationView` with setup of callout;
- Added `UserAnnotation` conforming to `MKAnnotation`;
- Creted convenience public - `UIImage`, `MKMapView`, `CLLocationCoordinate2D` - and fileprivate extensions;
- Wrote custom common `BaseViewController<ViewModel>` class;
- Implemented `reverseGeocodeLocation(_:)` to not spam `CLGeocoder` method call.
> After initiating a reverse-geocoding request, do not attempt to initiate another reverse- or forward-geocoding request. Geocoding requests are rate-limited for each app, so making too many requests in a short period of time may cause some of the requests to fail.